### PR TITLE
Use env utility in shebang

### DIFF
--- a/dockerfile-from-image.rb
+++ b/dockerfile-from-image.rb
@@ -1,4 +1,4 @@
-#! /usr/local/bin/ruby
+#!/usr/bin/env ruby
 require 'docker'
 require 'optparse'
 


### PR DESCRIPTION
A given system may not have Ruby installed at the expected path. When distributing a script, it is idiomatic to use the [env](http://www.gnu.org/software/coreutils/manual/html_node/env-invocation.html) utility in the shebang line, which will cause the first `ruby` executable in the `$PATH` to be used.
