### PR TITLE
upgrade to alpine 3.2 and update the README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM alpine:3.1
+FROM alpine:3.2
 MAINTAINER CenturyLink Labs <clt-labs-futuretech@centurylink.com>
 
-ENTRYPOINT ["/usr/src/app/dockerfile-from-image.rb"]
-CMD ["--help"]
-
-RUN apk update && apk add ruby-dev ca-certificates
+RUN apk --update add ruby-dev ca-certificates \
+    && rm /var/cache/apk/*
 RUN gem install --no-rdoc --no-ri docker-api
 
 ADD dockerfile-from-image.rb /usr/src/app/dockerfile-from-image.rb
+
+ENTRYPOINT ["/usr/src/app/dockerfile-from-image.rb"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ the Dockerfile for that image being generated.
     $ docker pull ruby
     Pulling repository ruby
 
-    $ docker run -v /run/docker.sock:/run/docker.sock centurylink/dockerfile-from-image
+    $ docker run --rm -v /run/docker.sock:/run/docker.sock centurylink/dockerfile-from-image
     Usage: dockerfile-from-image.rb [options] <image_id>
         -f, --full-tree                  Generate Dockerfile for all parent layers
         -h, --help                       Show this message
 
-    $ docker run -v /run/docker.sock:/run/docker.sock centurylink/dockerfile-from-image ruby
+    $ docker run --rm -v /run/docker.sock:/run/docker.sock centurylink/dockerfile-from-image ruby
     FROM buildpack-deps:latest
     RUN useradd -g users user
     RUN apt-get update && apt-get install -y bison procps
@@ -61,6 +61,18 @@ the Dockerfile for that image being generated.
     ONBUILD ADD . /usr/src/app
     ONBUILD WORKDIR /usr/src/app
     ONBUILD RUN [ ! -e Gemfile ] || bundle install --system
+
+### Run it as local command
+
+```
+$ docker pull centurylink/dockerfile-from-image
+$ alias dfimage="docker run --rm -v /var/run/docker.sock:/var/run/docker.sock centurylink/dockerfile-from-image"
+$ dfimage --help
+Usage: dockerfile-from-image.rb [options] <image_id>
+    -f, --full-tree                  Generate Dockerfile for all parent layers
+    -h, --help                       Show this message
+$ dfimage ruby
+```
 
 ### How Does It Work?
 


### PR DESCRIPTION
- upgrade to alpine 3.2
- reduce image size with cleaning the cache.

```
bwits/dockerfile-from-image                               latest              19038078a167        8 seconds ago       46.01 MB
centurylink/dockerfile-from-image                         latest              0b9883d906af        3 months ago        47.41 MB
centurylinklabs/dockerfile-from-image                     latest              1320bf815147        3 months ago        47.4 MB
```
- Update README and add instruction to run as local command
- move ENTRYPOINT and CMD command to the end , more logical.
- Add docker run command with option `--rm`, this is a neat way of tidying up for containers we only need once.
