### PR TITLE
adjust for smaller image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM alpine:3.2
 MAINTAINER CenturyLink Labs <clt-labs-futuretech@centurylink.com>
 
-RUN apk --update add ruby-dev ca-certificates \
-    && rm /var/cache/apk/*
-RUN gem install --no-rdoc --no-ri docker-api
+RUN apk --update add ruby-dev ca-certificates && \
+    gem install --no-rdoc --no-ri docker-api && \
+    apk del ruby-dev ca-certificates && \
+    apk add ruby ruby-bundler ruby-json && \
+    rm /var/cache/apk/*
 
 ADD dockerfile-from-image.rb /usr/src/app/dockerfile-from-image.rb
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER CenturyLink Labs <clt-labs-futuretech@centurylink.com>
 RUN apk --update add ruby-dev ca-certificates && \
     gem install --no-rdoc --no-ri docker-api && \
     apk del ruby-dev ca-certificates && \
-    apk add ruby ruby-bundler ruby-json && \
+    apk add ruby ruby-json && \
     rm /var/cache/apk/*
 
 ADD dockerfile-from-image.rb /usr/src/app/dockerfile-from-image.rb

--- a/dockerfile-from-image.rb
+++ b/dockerfile-from-image.rb
@@ -1,4 +1,4 @@
-#! /usr/bin/ruby
+#! /usr/bin/env ruby
 require 'docker'
 require 'optparse'
 
@@ -56,7 +56,7 @@ loop do
     if cmd.start_with?(NOP_PREFIX)
       commands << cmd.split(NOP_PREFIX).last
     else
-      commands << "RUN #{cmd}".squeeze(' ')
+      commands << "RUN #{cmd}".split.join(' ')
     end
   end
 


### PR DESCRIPTION
The reason we need `ruby-dev` package is, gem `docker-api` is native extension. 

My approach is to clean the bigger package `ruby-dev` after gem  `docker-api`  get installed, but still need install ruby back.

With this way, the image can be reduced from 46MB to 21MB

```
$ docker images |grep from
bwits/dockerfile-from-image             latest      f3fabf519fcf   7 minutes ago  21.12 MB
centurylinklabs/dockerfile-from-image   latest      c8fdfe6bfd0d   3 weeks ago    46.01 MB
```

I did test with this new image on several real images, and get proper result. 
