### PR TITLE
Skip iteration over untagged images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM alpine:3.2
+FROM alpine:3.5
 MAINTAINER CenturyLink Labs <clt-labs-futuretech@centurylink.com>
 
-RUN apk --update add ruby-dev ca-certificates && \
+RUN apk --update add ruby-dev ruby make gcc libc-dev ca-certificates && \
     gem install --no-rdoc --no-ri docker-api && \
-    apk del ruby-dev ca-certificates && \
-    apk add ruby ruby-json && \
+    apk del ruby-dev ca-certificates make gcc libc-dev && \
+    apk add ruby-json && \
     rm /var/cache/apk/*
 
 ADD dockerfile-from-image.rb /usr/src/app/dockerfile-from-image.rb

--- a/dockerfile-from-image.rb
+++ b/dockerfile-from-image.rb
@@ -30,7 +30,10 @@ abort('Error: Must specify image ID or tag') unless image_id
 # Collect all image tags into a hash keyed by layer ID.
 # Used to look-up potential FROM targets.
 tags = Docker::Image.all.each_with_object({}) do |image, hsh|
-  tag = image.info['RepoTags'].first
+  repo_tags = image.info['RepoTags']
+  # skip untagged images 
+  next if repo_tags.nil?
+  tag = repo_tags.first
   hsh[image.id] = tag unless tag == NONE_TAG
 end
 


### PR DESCRIPTION
Having untagged images present causes a failure with this error:

```
dockerfile-from-image.rb:33:in `block in <main>': undefined method `first' for nil:NilClass (NoMethodError)
    from dockerfile-from-image.rb:32:in `each'
    from dockerfile-from-image.rb:32:in `each_with_object'
    from dockerfile-from-image.rb:32:in `<main>'
```

This commit updates the script to simply ignore those images.
