### PR TITLE
Latest Alpine 3.6 as of 2017-10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.2
+FROM alpine:3.6
 MAINTAINER CenturyLink Labs <clt-labs-futuretech@centurylink.com>
 
-RUN apk --update add ruby-dev ca-certificates && \
+RUN apk add  --update ruby-dev ruby-json && \
     gem install --no-rdoc --no-ri docker-api && \
-    apk del ruby-dev ca-certificates && \
+    apk del ruby-dev && \
     apk add ruby ruby-json && \
     rm /var/cache/apk/*
 


### PR DESCRIPTION
Newer Alpine has current ca-certificates (and gem uses the properly) so that package isn't required anymore.
Newer Alpine's Ruby-dev 2.4.2 (vs 2.2.x of Alpine 3.2) does NOT appear to include gem or put it in the path as a command, but installing ruby-json pulls in gem. The second add for ruby-json was just to ensure if any bits were missing from removing ruby-dev that they got reinstalled.