### PR TITLE
Updating script to work in 2019

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,22 @@
-FROM alpine:3.2
+FROM alpine:latest
 MAINTAINER CenturyLink Labs <clt-labs-futuretech@centurylink.com>
 
-RUN apk --update add ruby-dev ca-certificates && \
-    gem install --no-rdoc --no-ri docker-api && \
-    apk del ruby-dev ca-certificates && \
-    apk add ruby ruby-json && \
+RUN apk --update add \
+    gcc \
+    libc-dev \
+    make \
+    ruby \
+    ruby-dev \
+    ruby-irb \
+    ruby-json && \
+    gem install --no-rdoc --no-ri bundler -v 1.16.1 && \
     rm /var/cache/apk/*
 
+WORKDIR /usr/src/app
+ADD Gemfile /usr/src/app/
+ADD Gemfile.lock /usr/src/app/
+RUN bundle
 ADD dockerfile-from-image.rb /usr/src/app/dockerfile-from-image.rb
 
-ENTRYPOINT ["/usr/src/app/dockerfile-from-image.rb"]
+ENTRYPOINT ["/usr/bin/bundle", "exec", "ruby", "/usr/src/app/dockerfile-from-image.rb"]
 CMD ["--help"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'docker'
+gem 'docker-api'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,21 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    backticks (1.0.2)
+    docker (0.4.0)
+      backticks (~> 1.0.0)
+    docker-api (1.34.2)
+      excon (>= 0.47.0)
+      multi_json
+    excon (0.62.0)
+    multi_json (1.13.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  docker
+  docker-api
+
+BUNDLED WITH
+   1.16.1

--- a/dockerfile-from-image.rb
+++ b/dockerfile-from-image.rb
@@ -30,8 +30,8 @@ abort('Error: Must specify image ID or tag') unless image_id
 # Collect all image tags into a hash keyed by layer ID.
 # Used to look-up potential FROM targets.
 tags = Docker::Image.all.each_with_object({}) do |image, hsh|
-  tag = image.info['RepoTags'].first
-  hsh[image.id] = tag unless tag == NONE_TAG
+  tag = image.info['RepoTags']&.first
+  hsh[image.id] = tag if tag && tag != NONE_TAG
 end
 
 loop do


### PR DESCRIPTION
This change pins the Docker image to a modern Alpine and introduces Gemfile.lock for pinning gem versions.

Using a Docker image built on this PR we can recreate the Dockerfile of the image:

```
$ dockerfile-from-image dockerfile-from-image:latest
FROM alpine:latest
RUN apk --update add gcc libc-dev make ruby ruby-dev ruby-irb ruby-json && gem install --no-rdoc --no-ri bundler -v 1.16.1 && rm /var/cache/apk/*
WORKDIR /usr/src/app
ADD file:8846919c69ba1db0d696b60c308789910d605613efbaabc9a39e922cefda1d9d in /usr/src/app/
ADD file:d4a7c1736d3fdf8b52906ed2f4e9b10cd5632a382fd493af2c6531fd11173a1f in /usr/src/app/
RUN bundle
ADD file:3ee34f17db9fd9bd8d12051a7959f986ae8705ba392c2d4f2bd28e097a896dde in /usr/src/app/dockerfile-from-image.rb
```